### PR TITLE
Replace *. with star. since tags cannot contain a *

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "aws_acm_certificate" "main" {
   subject_alternative_names = "${slice(var.domain_names, 1, length(var.domain_names))}"
   validation_method = "DNS"
   tags {
-    Name = "${var.domain_names[0]}"
+    Name = "${replace(var.domain_names[0], "*.", "star.")}"
     terraform = "true"
   }
 }


### PR DESCRIPTION
Ran into an issue where tags could not be applied to certs with wildcards in them. This changes `*.` to `star.` 

Before: 
```
aws_acm_certificate.main: ValidationException: 1 validation error detected: Value '*.mydomain.com' at 'tags.1.member.value' failed to satisfy constraint: Member must satisfy regular expression pattern: [\p{L}\p{Z}\p{N}_.:\/=+\-@]*
```

After (the plan):
```
+ module.wildcard_mydomain_com.aws_acm_certificate.main
      id:                          <computed>
      arn:                         <computed>
      domain_name:                 "*.mydomain.com"
      domain_validation_options.#: <computed>
      tags.%:                      "2"
      tags.Name:                   "star.mydomain.com"
      tags.terraform:              "true"
      validation_emails.#:         <computed>
      validation_method:           "DNS"
```

I verified that domain names that do not have a star in them are not touched.
